### PR TITLE
US 01.05.02/US 01.05.03

### DIFF
--- a/code/app/src/main/java/com/example/wizard_project/Controllers/WaitingListController.java
+++ b/code/app/src/main/java/com/example/wizard_project/Controllers/WaitingListController.java
@@ -122,6 +122,27 @@ public class WaitingListController {
                 .addOnFailureListener(onFailure::onFailure);
     }
 
+    /**
+     * Updates the status of a user in the waiting list for a specific event.
+     *
+     * @param eventId   The ID of the event for which the user's status is being updated. Must not be null.
+     * @param userId    The ID of the user whose status needs to be updated. Must not be null.
+     * @param newStatus The new status to set for the user (e.g., "Enrolled", "Cancelled"). Must not be null.
+     * @param callback  A callback to handle the result of the update operation, providing onSuccess or onFailure methods.
+     */
+    public void updateUserStatus(String eventId, String userId, String newStatus, OnActionCompleteListener callback) {
+        if (eventId == null || userId == null || newStatus == null) {
+            callback.onFailure(new IllegalArgumentException("Event ID, User ID, and New Status must not be null."));
+            return;
+        }
+
+        db.collection("events").document(eventId)
+                .collection("waitingList").document(userId)
+                .update("status", newStatus)
+                .addOnSuccessListener(aVoid -> callback.onSuccess())
+                .addOnFailureListener(callback::onFailure);
+    }
+
 
     /**
      * Retrieves the status of a user in the waiting list for a specific event.
@@ -142,6 +163,9 @@ public class WaitingListController {
                 })
                 .addOnFailureListener(callback::onFailure);
     }
+
+
+
 
     // Callback interfaces
     public interface OnCheckCompleteListener {

--- a/code/app/src/main/res/layout/fragment_view_event.xml
+++ b/code/app/src/main/res/layout/fragment_view_event.xml
@@ -315,4 +315,35 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/button_join_waiting_list" />
+
+
+    <!-- Entrant Accept Invitation Button-->
+    <Button
+        android:id="@+id/button_accept_invitation"
+        android:layout_width="300dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:backgroundTint="@color/lighter_purple"
+        android:text="@string/accept_invitation_button"
+        android:textColor="@color/white"
+        android:textSize="18sp"
+        android:visibility="invisible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button_view_facility" />
+
+    <!-- Entrant Deny Invitation Button-->
+    <Button
+        android:id="@+id/button_deny_invitation"
+        android:layout_width="300dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:backgroundTint="@color/lighter_purple"
+        android:text="@string/deny_invitation_button"
+        android:textColor="@color/white"
+        android:textSize="18sp"
+        android:visibility="invisible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button_accept_invitation" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/code/app/src/main/res/values/strings.xml
+++ b/code/app/src/main/res/values/strings.xml
@@ -44,6 +44,8 @@
     <string name="generate_qr_code">Generate QR Code</string>
     <string name="download_qr_code">Download QR Code</string>
     <string name="redraw_attendees_button">Redraw Attendees</string>
+    <string name="accept_invitation_button">Accept Invitation</string>
+    <string name="deny_invitation_button">Deny Invitation</string>
 
     <!-- Titles -->
     <string name="camera_title">Camera</string>


### PR DESCRIPTION
Added buttons and changes the status of the entrant if they accept invitation or deny invitiation. Currently, viewevent fragment just tracks the entrant status whether they are either waitlisted, cancelled, enrolled, selected and if they are any of those status they would be prompt to either accept invitation/ deny invitations or to join/leave waitlists. 